### PR TITLE
List/Dictionary Add and Remove Delegates

### DIFF
--- a/WinForms/PropertyEditing/PropertyEditors/IDictionaryPropertyEditor.cs
+++ b/WinForms/PropertyEditing/PropertyEditors/IDictionaryPropertyEditor.cs
@@ -12,23 +12,11 @@ using AdamsLair.WinForms.PropertyEditing.Templates;
 
 namespace AdamsLair.WinForms.PropertyEditing.Editors
 {
-	public class IDictionaryModifiedEventArgs : EventArgs
-	{
-		public IDictionary Dict { get; }
-		public object Key { get; }
-		public object Value { get; }
-
-		public IDictionaryModifiedEventArgs(IDictionary dict, object key, object value)
-		{
-			Dict = dict;
-			Key = key;
-			Value = value;
-		}
-	}
-
 	public class IDictionaryPropertyEditor : GroupedPropertyEditor
 	{
 		public delegate void KeyValueSetter(PropertyInfo property, IEnumerable<object> targetObjects, IEnumerable<object> values, object key);
+		public delegate void KeyAdder(IEnumerable<IDictionary> targetDictionaries, object key, Type valueType);
+		public delegate void KeyRemover(IEnumerable<IDictionary> targetDictionaries, object key);
 
 		private	bool					buttonIsCreate		= false;
 		private	PropertyEditor			addKeyEditor		= null;
@@ -37,10 +25,9 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 		private	int						offset				= 0;
 		private	int						internalEditors		= 0;
 		private	KeyValueSetter			dictKeySetter		= null;
+		private KeyAdder				dictKeyAdder		= null;
+		private KeyRemover				dictKeyRemover		= null;
 		private	object[]				displayedKeys		= null;
-
-		public event EventHandler<IDictionaryModifiedEventArgs> ItemAdded = null;
-		public event EventHandler<IDictionaryModifiedEventArgs> ItemRemoved = null;
 
 		public override object DisplayedValue
 		{
@@ -55,11 +42,31 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 				this.dictKeySetter = value;
 			}
 		}
+		public KeyAdder DictionKeyAdder
+		{
+			get { return this.dictKeyAdder; }
+			set
+			{
+				if (value == null) value = DefaultKeyAdder;
+				this.dictKeyAdder = value;
+			}
+		}
+		public KeyRemover DictionKeyRemover
+		{
+			get { return this.dictKeyRemover; }
+			set
+			{
+				if (value == null) value = DefaultKeyRemover;
+				this.dictKeyRemover = value;
+			}
+		}
 
 		public IDictionaryPropertyEditor()
 		{
 			this.Hints |= HintFlags.HasButton | HintFlags.ButtonEnabled;
 			this.dictKeySetter = DefaultPropertySetter;
+			this.dictKeyAdder = DefaultKeyAdder;
+			this.dictKeyRemover = DefaultKeyRemover;
 
 			this.offsetEditor = new NumericPropertyEditor();
 			this.offsetEditor.EditedType = typeof(int);
@@ -411,57 +418,13 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 			Type valueType = GetIDictionaryValueType(this.EditedType);
 			Type reflectedValueType = PropertyEditor.ReflectDynamicType(valueType, targetArray.Select(a => GetIDictionaryValueType(a.GetType())));
 
-			for (int t = 0; t < targetArray.Length; t++)
-			{
-				IDictionary target = targetArray[t];
-				if (target != null)
-				{
-					if (!target.IsFixedSize && !target.IsReadOnly)
-					{
-						if (!target.Contains(key))
-						{
-							// Add a new key value pair
-							object addedValue = valueType.IsValueType ? reflectedValueType.CreateInstanceOf() : null;
-							target.Add(key, addedValue);
-
-							if (ItemAdded != null)
-								ItemAdded(this, new IDictionaryModifiedEventArgs(target, key, addedValue));
-						}
-					}
-					else
-					{
-						// Just some read-only container? Well, can't do anything here.
-					}
-				}
-			}
+			this.dictKeyAdder(targetArray, key, reflectedValueType);
 		}
 		private void RemoveKeyFromDictionary(object key)
 		{
 			IDictionary[] targetArray = this.GetValue().Cast<IDictionary>().Where(v => v != null).ToArray();
-			Type valueType = GetIDictionaryValueType(this.EditedType);
 
-			for (int t = 0; t < targetArray.Length; t++)
-			{
-				IDictionary target = targetArray[t];
-				if (target != null)
-				{
-					if (!target.IsFixedSize && !target.IsReadOnly)
-					{
-						if (target.Contains(key))
-						{
-							object removedValue = target[key];
-							target.Remove(key);
-
-							if (ItemRemoved != null)
-								ItemRemoved(this, new IDictionaryModifiedEventArgs(target, key, removedValue));
-						}
-					}
-					else
-					{
-						// Just some read-only container? Well, can't do anything here.
-					}
-				}
-			}
+			this.dictKeyRemover(targetArray, key);
 		}
 		
 		protected static Type GetIDictionaryValueType(Type dictType)
@@ -494,6 +457,48 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 			{
 				if (target != null) property.SetValue(target, curValue, new object[] {key});
 				if (valuesEnum.MoveNext()) curValue = valuesEnum.Current;
+			}
+		}
+		protected static void DefaultKeyAdder(IEnumerable<IDictionary> targetDictionaries, object key, Type valueType)
+		{
+			foreach (IDictionary target in targetDictionaries)
+			{
+				if (target != null)
+				{
+					if (!target.IsFixedSize && !target.IsReadOnly)
+					{
+						if (!target.Contains(key))
+						{
+							// Add a new key value pair
+							object addedValue = valueType.IsValueType ? valueType.CreateInstanceOf() : null;
+							target.Add(key, addedValue);
+						}
+					}
+					else
+					{
+						// Just some read-only container? Well, can't do anything here.
+					}
+				}
+			}
+		}
+		protected static void DefaultKeyRemover(IEnumerable<IDictionary> targetDictionaries, object key)
+		{
+			foreach (IDictionary target in targetDictionaries)
+			{
+				if (target != null)
+				{
+					if (!target.IsFixedSize && !target.IsReadOnly)
+					{
+						if (target.Contains(key))
+						{
+							target.Remove(key);
+						}
+					}
+					else
+					{
+						// Just some read-only container? Well, can't do anything here.
+					}
+				}
 			}
 		}
 	}

--- a/WinForms/PropertyEditing/PropertyEditors/IListPropertyEditor.cs
+++ b/WinForms/PropertyEditing/PropertyEditors/IListPropertyEditor.cs
@@ -264,6 +264,7 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 			IEnumerator<object> valuesEnum = values.GetEnumerator();
 			IList<IList> targetLists = this.GetValue().Cast<IList>().ToList();
 			Type elementType = GetIListElementType(this.EditedType);
+			Type reflectedElementType = PropertyEditor.ReflectDynamicType(elementType, targetLists.Select(a => GetIListElementType(a.GetType())));
 
 			int maxSize = 0;
 			while (valuesEnum.MoveNext())
@@ -274,7 +275,7 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 
 			if (maxSize > MaxAllowedListSize) maxSize = MaxAllowedListSize;
 
-			bool writeBack = this.listResizer(targetLists, maxSize, elementType);
+			bool writeBack = this.listResizer(targetLists, maxSize, reflectedElementType);
 
 			if (writeBack || this.ForceWriteBack) this.SetValues(targetLists);
 			this.PerformGetValue();
@@ -381,7 +382,6 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 		protected static bool DefaultListResizer(IList<IList> targetLists, int size, Type elementType)
 		{
 			bool writeback = false;
-			Type reflectedArrayType = null;
 
 			for (int i = 0; i < targetLists.Count; i++)
 			{
@@ -398,10 +398,7 @@ namespace AdamsLair.WinForms.PropertyEditing.Editors
 				}
 				else if (target is Array)
 				{
-					if (reflectedArrayType == null)
-						reflectedArrayType = PropertyEditor.ReflectDynamicType(elementType, targetLists.Select(a => GetIListElementType(a.GetType())));
-
-					Array newTarget = Array.CreateInstance(reflectedArrayType, size);
+					Array newTarget = Array.CreateInstance(elementType, size);
 					for (int j = 0; j < Math.Min(size, target.Count); j++) newTarget.SetValue(target[j], j);
 					targetLists[i] = newTarget;
 					writeback = true;

--- a/WinForms/PropertyEditing/PropertyGrid.cs
+++ b/WinForms/PropertyEditing/PropertyGrid.cs
@@ -160,7 +160,7 @@ namespace AdamsLair.WinForms.PropertyEditing
 				// IList
 				else if (typeof(System.Collections.IList).IsAssignableFrom(baseType))
 					e = new IListPropertyEditor();
-				// IList
+				// IDictionary
 				else if (typeof(System.Collections.IDictionary).IsAssignableFrom(baseType))
 					e = new IDictionaryPropertyEditor();
 				// Unknown data type


### PR DESCRIPTION
### Summary
Added delegates for IList resize and IDictionary key add and remove operations.

### Details
- Matches existing pattern of list index and key value setter delegates
- Default implementation of delegates matches previous behavior
- IList uses a single Resize delegate rather than add/remove

Rather than sending the elementType to IList/IDict delegates, I sent the reflected element type. In all cases, that is what was being used to create elements or to resize arrays. Previously, the element type was being used when creating elements like so: `elementType.IsValueType ? reflectedElementType.CreateInstanceOf() : null`. I cannot think of any case in which we could not just use reflectedElementType for this line. The reflected type is what is going into the collection so I don't see how the elementType should affect what gets put in like this. In the case that no valid reflected type is found, `elementType == reflectedElementType`.

See [here](https://github.com/AdamsLair/duality/issues/426) for original discussion of implementation.