### PR TITLE
ExpandState XML saving

### DIFF
--- a/WinForms/PropertyEditing/GroupedPropertyEditor.cs
+++ b/WinForms/PropertyEditing/GroupedPropertyEditor.cs
@@ -46,6 +46,7 @@ namespace AdamsLair.WinForms.PropertyEditing
 		public event EventHandler<PropertyEditorEventArgs>	EditorAdded;
 		public event EventHandler<PropertyEditorEventArgs>	EditorRemoving;
 		public event EventHandler							ActiveChanged;
+		public event EventHandler							ExpandedChanged;
 		
 
 		public bool Expanded
@@ -56,6 +57,7 @@ namespace AdamsLair.WinForms.PropertyEditing
 				if (this.expanded != value)
 				{
 					this.expanded = value;
+					if (this.ExpandedChanged != null) ExpandedChanged(this, EventArgs.Empty);
 					if (this.ParentGrid != null)
 					{
 						this.Invalidate();

--- a/WinForms/PropertyEditing/GroupedPropertyEditor.cs
+++ b/WinForms/PropertyEditing/GroupedPropertyEditor.cs
@@ -46,7 +46,6 @@ namespace AdamsLair.WinForms.PropertyEditing
 		public event EventHandler<PropertyEditorEventArgs>	EditorAdded;
 		public event EventHandler<PropertyEditorEventArgs>	EditorRemoving;
 		public event EventHandler							ActiveChanged;
-		public event EventHandler							ExpandedChanged;
 		
 
 		public bool Expanded
@@ -57,7 +56,6 @@ namespace AdamsLair.WinForms.PropertyEditing
 				if (this.expanded != value)
 				{
 					this.expanded = value;
-					if (this.ExpandedChanged != null) ExpandedChanged(this, EventArgs.Empty);
 					if (this.ParentGrid != null)
 					{
 						this.Invalidate();

--- a/WinForms/PropertyEditing/PropertyGrid.cs
+++ b/WinForms/PropertyEditing/PropertyGrid.cs
@@ -91,14 +91,13 @@ namespace AdamsLair.WinForms.PropertyEditing
 		}
 		public void SaveToXml(XElement node)
 		{
-			string expandedString = string.Concat(this.expandedNodes.Select(s => s + ","));
-			node.SetElementValue("ExpandedNodes", expandedString);
+			node.Add(new XElement("ExpandedNodes", this.expandedNodes.Select(n => new XElement("NodeID", n))));
 		}
 		public void LoadFromXml(XElement node)
 		{
 			XElement expandedElement = node.Element("ExpandedNodes");
 			this.expandedNodes = expandedElement != null
-				? new HashSet<string>(expandedElement.Value.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries))
+				? new HashSet<string>(expandedElement.Elements("NodeID").Select(elem => elem.Value))
 				: new HashSet<string>();
 		}
 

--- a/WinForms/PropertyEditing/PropertyGrid.cs
+++ b/WinForms/PropertyEditing/PropertyGrid.cs
@@ -228,7 +228,6 @@ namespace AdamsLair.WinForms.PropertyEditing
 
 		public event EventHandler<PropertyEditorValueEventArgs>	EditingFinished = null;
 		public event EventHandler<PropertyEditorValueEventArgs>	ValueChanged	= null;
-		public event EventHandler<PropertyEditorEventArgs>		ExpandedChanged = null;
 
 
 		public IEnumerable<object> Selection
@@ -481,15 +480,6 @@ namespace AdamsLair.WinForms.PropertyEditing
 		}
 		public virtual void ConfigureEditor(PropertyEditor editor, object configureData = null)
 		{
-			if (editor is GroupedPropertyEditor)
-			{
-				GroupedPropertyEditor groupedEditor = editor as GroupedPropertyEditor;
-				groupedEditor.ExpandedChanged += (s, e) =>
-				{
-					if (this.ExpandedChanged != null)
-						this.ExpandedChanged(this, new PropertyEditorEventArgs(editor));
-				};
-			}
 			editor.ConfigureEditor(configureData);
 		}
 		public virtual object CreateObjectInstance(Type objectType)

--- a/WinForms/PropertyEditing/PropertyGrid.cs
+++ b/WinForms/PropertyEditing/PropertyGrid.cs
@@ -8,6 +8,7 @@ using System.Drawing.Drawing2D;
 using System.ComponentModel;
 using System.Reflection;
 using System.Xml.Linq;
+
 using AdamsLair.WinForms.PropertyEditing.Editors;
 using AdamsLair.WinForms.Drawing;
 using AdamsLair.WinForms.NativeWinAPI;


### PR DESCRIPTION
Added the ability to save/load ExpandState objects from XML.

Part of work on [this Duality feature](https://github.com/AdamsLair/duality/issues/244).